### PR TITLE
Sync API docs from bc3: explicit status=active on the projects index

### DIFF
--- a/sections/projects.md
+++ b/sections/projects.md
@@ -18,7 +18,7 @@ Get all projects
 
 _Optional parameters_:
 
-* `status` - when set to `archived` or `trashed`, will return archived or trashed projects visible to the current user.
+* `status` - set to `active`, `archived`, or `trashed` to filter projects by status.
 
 ###### Example JSON Response
 <!-- START GET /projects.json -->


### PR DESCRIPTION
The projects index now accepts `status=active` as an explicit value — an alias of the default — alongside `archived` and `trashed`, per basecamp/bc3#13037. This updates the `status` parameter docs on [Get all projects](sections/projects.md#get-all-projects) to match.

Synced from bc3 `doc/api/` by `script/api/sync_to_bc3_api` — not a hand-edit.